### PR TITLE
Add pre-commit secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
This adds a pre-commit hook that runs Gitleaks against staged changes before they are committed.

Created by `github-ops rollout apply` with the `pre-commit-secrets` file set.