### PR TITLE
feat: add reusable docs index workflow

### DIFF
--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -1,0 +1,21 @@
+name: Reusable CodeQL
+
+on:
+  workflow_call:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/reusable-docs-index.yml
+++ b/.github/workflows/reusable-docs-index.yml
@@ -1,0 +1,94 @@
+name: Reusable docs index
+
+on:
+  workflow_call:
+    inputs:
+      docs_directory:
+        description: Directory containing Markdown docs.
+        required: false
+        default: docs
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docs-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Regenerate docs index
+        shell: bash
+        env:
+          DOCS_DIR: ${{ inputs.docs_directory }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -d "$DOCS_DIR" ]; then
+            echo "No $DOCS_DIR directory found; nothing to index."
+            exit 0
+          fi
+
+          tmp="$(mktemp)"
+          {
+            echo "# Docs index"
+            echo
+            echo 'Auto-maintained by the `docs-index-update` skill. Edit individual docs, not this file.'
+            echo
+            echo "## Entries"
+            echo
+
+            find "$DOCS_DIR" -name '*.md' ! -name 'INDEX.md' | sort | while IFS= read -r file; do
+              title="$(sed -n 's/^# //p' "$file" | head -n 1)"
+              if [ -z "$title" ]; then
+                title="$(basename "$file" .md)"
+              fi
+
+              summary="$(awk '
+                /^# / && !seen_title { seen_title = 1; next }
+                seen_title && NF && $0 !~ /^#/ {
+                  gsub(/[[:space:]]+/, " ")
+                  print
+                  exit
+                }
+              ' "$file")"
+
+              if [ "${#summary}" -gt 150 ]; then
+                summary="${summary:0:147}..."
+              fi
+
+              link="${file#"$DOCS_DIR"/}"
+              if [ -n "$summary" ]; then
+                printf -- "- [%s](%s) — %s\n" "$title" "$link" "$summary"
+              else
+                printf -- "- [%s](%s)\n" "$title" "$link"
+              fi
+            done
+          } > "$tmp"
+
+          if [ -f "$DOCS_DIR/INDEX.md" ] && cmp -s "$tmp" "$DOCS_DIR/INDEX.md"; then
+            echo "docs index is already current"
+            rm "$tmp"
+          else
+            mv "$tmp" "$DOCS_DIR/INDEX.md"
+          fi
+
+      - name: Open docs index PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: self-improvement/docs-index
+          commit-message: "docs: refresh INDEX.md"
+          title: "docs: refresh INDEX.md"
+          body: |
+            ## Summary
+            - Regenerated the docs index from the current Markdown files.
+
+            ## Test plan
+            - [x] Regenerated `docs/INDEX.md`
+
+            ## Links
+            Self-improvement: docs-index
+          labels: self-improvement
+          draft: true

--- a/.github/workflows/reusable-secret-scan.yml
+++ b/.github/workflows/reusable-secret-scan.yml
@@ -1,0 +1,27 @@
+name: Reusable secret scan
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan for common committed secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pattern='-----BEGIN (RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY-----|ghp_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{82,}|AKIA[0-9A-Z]{16}'
+
+          if git grep -I -n -E "$pattern" -- . ':!*.png' ':!*.jpg' ':!*.jpeg' ':!*.gif' ':!*.svg'; then
+            echo "::error::Potential committed secret found. Review the matches above."
+            exit 1
+          fi
+
+          echo "No common committed secret patterns found."

--- a/.github/workflows/reusable-self-improvement.yml
+++ b/.github/workflows/reusable-self-improvement.yml
@@ -1,0 +1,27 @@
+name: Reusable self-improvement
+
+on:
+  workflow_call:
+    inputs:
+      goal:
+        description: Goal for the self-improvement agent.
+        required: false
+        default: Survey the repository and propose one focused improvement PR.
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  self-improvement:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Not yet configured
+        env:
+          GOAL: ${{ inputs.goal }}
+        run: |
+          echo "::error::Reusable self-improvement is not wired to a code agent yet."
+          echo "Requested goal: $GOAL"
+          echo "Wire this workflow to Claude Code Action or another GitHub-native agent before enabling scheduled all-job runs."
+          exit 1

--- a/.github/workflows/reusable-test-coverage.yml
+++ b/.github/workflows/reusable-test-coverage.yml
@@ -1,0 +1,18 @@
+name: Reusable test coverage
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Not yet configured
+        run: |
+          echo "::error::Reusable test coverage is not wired to a coverage provider yet."
+          echo "Configure Codecov or a repository-specific coverage artifact contract before enabling scheduled all-job runs."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds the reusable workflow files expected by template repos at `@v1`.
- Implements the docs-index reusable workflow so template repos can regenerate `docs/INDEX.md` and open a draft self-improvement PR when it changes.
- Adds callable CodeQL and secret-scan workflows, plus explicit failing placeholders for coverage and general self-improvement until those integrations are wired.
- Published the same commit to the initial `v1` branch so `maestro-org/ai-first-repo-template` can test its existing self-improvement references.

## Test plan
- [x] `git diff --check`
- [x] Dispatched `Self-improvement loop` with `jobs=docs-index`: https://github.com/maestro-org/ai-first-repo-template/actions/runs/26538685138
- [x] Confirmed docs-index opened draft PR maestro-org/ai-first-repo-template#23
- [x] Dispatched `Self-improvement loop` with `jobs=secret-scan`: https://github.com/maestro-org/ai-first-repo-template/actions/runs/26538809867
- [x] Dispatched `Self-improvement loop` with `jobs=codeql`: https://github.com/maestro-org/ai-first-repo-template/actions/runs/26539104430
- [x] Confirmed CodeQL runs through analysis; upload is blocked until Code Security is enabled on the template repo

## Links
Related: maestro-org/ai-first-repo-template#22