### PR TITLE
fix: harden docs index PR creation

### DIFF
--- a/.github/workflows/reusable-docs-index.yml
+++ b/.github/workflows/reusable-docs-index.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Open docs index PR
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: self-improvement/docs-index
+          branch: self-improvement/docs-index/${{ github.ref_name }}
           commit-message: "docs: refresh INDEX.md"
           title: "docs: refresh INDEX.md"
           body: |
@@ -92,5 +92,6 @@ jobs:
 
             ## Links
             Self-improvement: docs-index
+            Base ref: `${{ github.ref_name }}`
           labels: self-improvement
           draft: true

--- a/.github/workflows/reusable-docs-index.yml
+++ b/.github/workflows/reusable-docs-index.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Regenerate docs index
         shell: bash
@@ -76,7 +78,7 @@ jobs:
           fi
 
       - name: Open docs index PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: self-improvement/docs-index
           commit-message: "docs: refresh INDEX.md"


### PR DESCRIPTION
## Summary
- Disables checkout credential persistence in the reusable docs-index workflow so create-pull-request can manage git auth without duplicate Authorization headers.
- Updates peter-evans/create-pull-request from v6 to v8.
- Scopes generated docs-index branches by base ref so branch-dispatch smoke tests cannot overwrite the main docs-index PR branch.
- Published the same commits to the v1 branch for live template testing.

## Test plan
- [x] `git diff --check`
- [x] YAML parse check for `.github/workflows/reusable-docs-index.yml`
- [x] Dispatch ai-first-repo-template self-improvement with `jobs=secret-scan,docs-index`: https://github.com/maestro-org/ai-first-repo-template/actions/runs/26543439497
- [x] Confirmed generated draft PR against main uses scoped head branch: https://github.com/maestro-org/ai-first-repo-template/pull/27
- [x] Confirmed branch dispatch used a separate scoped head branch: https://github.com/maestro-org/ai-first-repo-template/actions/runs/26543462834

## Links
Related: maestro-org/ai-first-repo-template self-improvement loop test